### PR TITLE
Missing imports

### DIFF
--- a/src/fm/last/irccat/IRCCat.java
+++ b/src/fm/last/irccat/IRCCat.java
@@ -22,6 +22,8 @@ import org.jibble.pircbot.*;
 import java.net.*;
 import java.io.*;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 public class IRCCat extends PircBot {
 


### PR DESCRIPTION
I couldn't build on Mac OS X without adding these imports.

```
java version "1.6.0_24"
Java(TM) SE Runtime Environment (build 1.6.0_24-b07-334-10M3326)
Java HotSpot(TM) 64-Bit Server VM (build 19.1-b02-334, mixed mode)
```
