### PR TITLE
Add deop, op built-in commands.

### DIFF
--- a/src/fm/last/irccat/IRCCat.java
+++ b/src/fm/last/irccat/IRCCat.java
@@ -326,6 +326,18 @@ public class IRCCat extends PircBot {
 			return "Joining: " + toks[1];
 		}
 
+		// GIVE SOMEONE AN OP
+		if (method.equals("op") && toks.length == 3){
+			op(toks[1], toks[2]);
+			return "Giving " + toks[2] + " op";
+		}
+
+		// DEOP SOMEONE
+		if (method.equals("deop") && toks.length == 3){
+			deOp(toks[1], toks[2]);
+			return "Taking op from " + toks[2];
+		}
+
 		// PART A CHANNEL
 		if (method.equals("part") && toks.length == 2) {
 			sendMessage(toks[1], "<" + sender + "> !" + cmd);


### PR DESCRIPTION
Giving or taking op is a basic IRC command we frequently use.
In this pull request, I want to propose two commands that give op or take op by trusted persons.

```
trusted>> !op #chan RJ
trusted>> !deop #chan RJ
```

Thank you.
