### PR TITLE
Change maxCmdResponseLines to be per channel

### DIFF
--- a/examples/irccat.xml
+++ b/examples/irccat.xml
@@ -25,7 +25,7 @@
 	<!-- Settings for calling external scripts to handle commands -->
 	<script>
 		<cmdhandler>scripts/cmd_handler.sh</cmdhandler>
-		<maxresponselines>15</maxresponselines>
+		<defaultmaxresponselines>15</defaultmaxresponselines>
 	</script>
 	
 	<!-- Which channels to join on startup -->
@@ -34,6 +34,7 @@
 		<channel>
 			<name>testchan1</name>
 			<password>blah</password>
+            <maxresponselines>5</maxresponselines>
 		</channel>
 		<channel>
 			<name>testchan2</name>

--- a/src/fm/last/irccat/IRCCat.java
+++ b/src/fm/last/irccat/IRCCat.java
@@ -31,7 +31,6 @@ public class IRCCat extends PircBot {
 	private String cmdScript;
 	private String defaultChannel = null;
     private HashMap<String, Integer> maxCmdResponseLines = new HashMap();
-	//private int maxCmdResponseLines = 26;
 	private XMLConfiguration config;
 
 	public static void main(String[] args) throws Exception {
@@ -102,7 +101,7 @@ public class IRCCat extends PircBot {
 		List<HierarchicalConfiguration> chans = config
 				.configurationsAt("channels.channel");
 		for (HierarchicalConfiguration chan : chans) {
-            maxCmdResponseLines.put("#" + chan.getString("name"), chan.getInteger("maxresponselines", null));
+            maxCmdResponseLines.put("#" + chan.getString("name"), chan.getInteger("maxresponselines", maxCmdResponseLines.get("default")));
         }
 		setName(nick);
 		setLogin(nick);

--- a/src/fm/last/irccat/IRCCat.java
+++ b/src/fm/last/irccat/IRCCat.java
@@ -78,8 +78,8 @@ public class IRCCat extends PircBot {
 			while (true) {
 				try {
 					Socket clientSocket = serverSocket.accept();
-					 System.out.println("Connection on catport from: "
-					 + clientSocket.getInetAddress().toString());
+					 //System.out.println("Connection on catport from: "
+					 //+ clientSocket.getInetAddress().toString());
 					CatHandler handler = new CatHandler(clientSocket, bot);
 					handler.start();
 				} catch (Exception e) {

--- a/src/fm/last/irccat/IRCCat.java
+++ b/src/fm/last/irccat/IRCCat.java
@@ -78,8 +78,8 @@ public class IRCCat extends PircBot {
 			while (true) {
 				try {
 					Socket clientSocket = serverSocket.accept();
-					// System.out.println("Connection on catport from: "
-					// + clientSocket.getInetAddress().toString());
+					 System.out.println("Connection on catport from: "
+					 + clientSocket.getInetAddress().toString());
 					CatHandler handler = new CatHandler(clientSocket, bot);
 					handler.start();
 				} catch (Exception e) {
@@ -102,7 +102,6 @@ public class IRCCat extends PircBot {
 		List<HierarchicalConfiguration> chans = config
 				.configurationsAt("channels.channel");
 		for (HierarchicalConfiguration chan : chans) {
-            System.out.println("Channel " + chan + " has a max response limit of " + chan.getInteger("maxresponselines", null));
             maxCmdResponseLines.put("#" + chan.getString("name"), chan.getInteger("maxresponselines", null));
         }
 		setName(nick);
@@ -138,7 +137,6 @@ public class IRCCat extends PircBot {
     }
 
 	public int getCmdMaxResponseLines(String chan) {
-        System.out.println("Checking max response lines of channel " + chan);
         if (chan != null) {
             if (maxCmdResponseLines.containsKey(chan)) {
                 return maxCmdResponseLines.get(chan);

--- a/src/fm/last/irccat/IRCCat.java
+++ b/src/fm/last/irccat/IRCCat.java
@@ -32,6 +32,7 @@ public class IRCCat extends PircBot {
 	private String defaultChannel = null;
     private HashMap<String, Integer> maxCmdResponseLines = new HashMap();
 	private XMLConfiguration config;
+    private bool mute = false;
 
 	public static void main(String[] args) throws Exception {
 		try {
@@ -273,6 +274,11 @@ public class IRCCat extends PircBot {
 	public void handleMessage(String channel_, String sender, String message) {
 		String cmd;
 		String respondTo = channel_ == null ? sender : channel_;
+
+        if (mute) {
+            // we are muted, don't say anything at all
+            return;
+        };
 		
 		
 		
@@ -361,6 +367,17 @@ public class IRCCat extends PircBot {
 				sb.append(c[i] + " ");
 			return sb.toString();
 		}
+
+        // MUTE THE BOT
+        if (method.equals("mute")) {
+          this.catStuffToAll("<" + sender + ">" + " has muted me. !unmute to unmute");
+          mute = true;
+        }
+
+        // UNMUTE THE BOT
+        if (method.equals("unmute")) {
+          mute = false;
+        }
 
 		// EXIT()
 		if (method.equals("exit"))

--- a/src/fm/last/irccat/IRCCat.java
+++ b/src/fm/last/irccat/IRCCat.java
@@ -132,11 +132,11 @@ public class IRCCat extends PircBot {
 		return cmdScript;
 	}
 
-    public int getCmdMaxResponseLines() {
+    public int getMaxCmdResponseLines() {
         return maxCmdResponseLines.get("default");
     }
 
-	public int getCmdMaxResponseLines(String chan) {
+	public int getMaxCmdResponseLines(String chan) {
         if (chan != null) {
             if (maxCmdResponseLines.containsKey(chan)) {
                 return maxCmdResponseLines.get(chan);

--- a/src/fm/last/irccat/Scripter.java
+++ b/src/fm/last/irccat/Scripter.java
@@ -40,7 +40,6 @@ class Scripter extends Thread {
                 InputStreamReader isr = new InputStreamReader(is, "UTF-8");
                 BufferedReader br = new BufferedReader(isr);
                 String line;
-                System.out.println(channel + " has a max response of " + bot.getCmdMaxResponseLines(channel));
                 int i=0;
                 while ((line = br.readLine()) != null) {
                     bot.sendMsg(returnName, line);

--- a/src/fm/last/irccat/Scripter.java
+++ b/src/fm/last/irccat/Scripter.java
@@ -40,6 +40,7 @@ class Scripter extends Thread {
                 InputStreamReader isr = new InputStreamReader(is, "UTF-8");
                 BufferedReader br = new BufferedReader(isr);
                 String line;
+                System.out.println(channel + " has a max response of " + bot.getCmdMaxResponseLines(channel));
                 int i=0;
                 while ((line = br.readLine()) != null) {
                     bot.sendMsg(returnName, line);

--- a/src/fm/last/irccat/Scripter.java
+++ b/src/fm/last/irccat/Scripter.java
@@ -40,10 +40,11 @@ class Scripter extends Thread {
                 InputStreamReader isr = new InputStreamReader(is, "UTF-8");
                 BufferedReader br = new BufferedReader(isr);
                 String line;
+                System.out.println(channel + " has a max response of " + bot.getCmdMaxResponseLines(channel));
                 int i=0;
                 while ((line = br.readLine()) != null) {
                     bot.sendMsg(returnName, line);
-                    if(++i==bot.getCmdMaxResponseLines()){
+                    if(++i==bot.getCmdMaxResponseLines(channel)){
                         bot.sendMsg(returnName, "<truncated, too many lines>");
                         break;
                     }

--- a/src/fm/last/irccat/Scripter.java
+++ b/src/fm/last/irccat/Scripter.java
@@ -43,7 +43,7 @@ class Scripter extends Thread {
                 int i=0;
                 while ((line = br.readLine()) != null) {
                     bot.sendMsg(returnName, line);
-                    if(++i==bot.getCmdMaxResponseLines(channel)){
+                    if(++i==bot.getMaxCmdResponseLines(channel)){
                         bot.sendMsg(returnName, "<truncated, too many lines>");
                         break;
                     }


### PR DESCRIPTION
Changes:

* Changed maxCmdResponseLines to a Hashmap<String, Integer> so that it could store the max response lines on a per channel basis.
* Changed getCmdMaxResponseLines to getMaxCmdResponseLines to be consistent with the variable name.