### PR TITLE
Adding login forwarding via config

### DIFF
--- a/examples/command_runner.py
+++ b/examples/command_runner.py
@@ -9,10 +9,15 @@ import os, sys, re, subprocess
 # a script in whatever language you like. Command names are limited to [0-9a-z].
 
 path = '/usr/share/irccat/'
+includeLogin = False
 
 args = sys.argv[1]
 bits = args.split(' ')
-command = bits[3].lower()
+commandIdx = 3
+if includeLogin:
+    commandIdx = 4
+
+command = bits[commandIdx].lower()
 
 found = False
 if re.match('^[a-z0-9]+$', command):

--- a/examples/example.php
+++ b/examples/example.php
@@ -2,11 +2,16 @@
 /**
     Don't add stupid commands about ponies or paris hilton :)
 **/
+$includeLogin = false;
+
 $input = $_SERVER['argv'][1];
 $toks = explode(" ",$input);
 $nick = array_shift($toks);
 $channel = array_shift($toks);
 $sender = array_shift($toks);
+if ($includeLogin) {
+    $login = array_shift($toks);
+}
 $first = array_shift($toks);
 
 // switch on first word (the command word)

--- a/examples/irccat.xml
+++ b/examples/irccat.xml
@@ -27,7 +27,12 @@
 		<cmdhandler>scripts/cmd_handler.sh</cmdhandler>
 		<maxresponselines>15</maxresponselines>
 	</script>
-	
+
+    <!-- Settings for extra fields to pass to command handler before command text -->
+    <fields>
+        <includelogin>false</includelogin>
+    </fields>
+
 	<!-- Which channels to join on startup -->
 	<!-- First channel in list is "default channel", and all members are implicitly trusted -->
 	<channels>

--- a/src/fm/last/irccat/IRCCat.java
+++ b/src/fm/last/irccat/IRCCat.java
@@ -29,6 +29,7 @@ public class IRCCat extends PircBot {
 
 	private String nick;
 	private String cmdScript;
+	private boolean includeLogin;
 	private String defaultChannel = null;
 	private int maxCmdResponseLines = 26;
 	private XMLConfiguration config;
@@ -97,6 +98,7 @@ public class IRCCat extends PircBot {
 		setEncoding("UTF8");
 		cmdScript = config.getString("script.cmdhandler");
 		maxCmdResponseLines = config.getInt("script.maxresponselines", 26);
+		includeLogin = config.getBoolean("fields.includelogin", false);
 		nick = config.getString("bot.nick");
 		setName(nick);
 		setLogin(nick);
@@ -128,6 +130,10 @@ public class IRCCat extends PircBot {
 
 	public int getCmdMaxResponseLines() {
 		return maxCmdResponseLines;
+	}
+
+	public boolean getIncludeLogin() {
+		return includeLogin;
 	}
 
 	protected void onDisconnect(){
@@ -180,7 +186,7 @@ public class IRCCat extends PircBot {
 	// PM was sent to us on irc
 	public void onPrivateMessage(String sender, String login, String hostname,
 			String message) {
-		handleMessage(null, sender, message);
+		handleMessage(null, sender, login, message);
 	}
 
     public void changeTopic(String target, String topic) {
@@ -227,7 +233,7 @@ public class IRCCat extends PircBot {
 	// message sent to our channel
 	public void onMessage(String channel_, String sender, String login,
 			String hostname, String message) {
-		handleMessage(channel_, sender, message);
+		handleMessage(channel_, sender, login, message);
 	}
 
 	public void onPart(String _channel, String _sender, String _login,
@@ -264,7 +270,7 @@ public class IRCCat extends PircBot {
 		return false;
 	}
 	
-	public void handleMessage(String channel_, String sender, String message) {
+	public void handleMessage(String channel_, String sender, String login, String message) {
 		String cmd;
 		String respondTo = channel_ == null ? sender : channel_;
 		
@@ -310,8 +316,8 @@ public class IRCCat extends PircBot {
 		
 		// now "cmd" contains the message, minus the address prefix (eg: ?)
 		// hand off msg to thread that executes shell script
-        System.out.println("Scripter: ["+respondTo+"] <"+sender+"> "+message);
-		Thread t = new Scripter(sender, channel_, respondTo, cmd, this);
+		System.out.println("Scripter: ["+respondTo+"] <"+sender+"> "+message);
+		Thread t = new Scripter(sender, channel_, respondTo, login, cmd, this);
 		t.run();
 	}
 

--- a/src/fm/last/irccat/Scripter.java
+++ b/src/fm/last/irccat/Scripter.java
@@ -22,11 +22,12 @@ import java.io.*;
 // hands off cmd to shell script and returns stdout to the requester
 class Scripter extends Thread {
         IRCCat bot;
-        String nick, channel, returnName, cmd;
+        String nick, channel, returnName, login, cmd;
 
-        Scripter(String nk, String ch, String r, String c, IRCCat b){
+        Scripter(String nk, String ch, String r, String l, String c, IRCCat b){
             nick = nk;
             channel = ch;
+            login = l;
             cmd = c;
             returnName = r;
             bot = b;
@@ -34,8 +35,13 @@ class Scripter extends Thread {
 
         public void run(){
             try{
+                String msg = nick + " " + channel + " " + returnName;
+                if (bot.getIncludeLogin()) {
+                    msg = msg + " " + login;
+                }
+                msg = msg + " " + cmd;
                 Runtime runtime = Runtime.getRuntime();
-                Process process = runtime.exec(new String[]{bot.getCmdScript() ,nick + " " + channel + " " + returnName+" "+cmd});
+                Process process = runtime.exec(new String[]{bot.getCmdScript(), msg});
                 InputStream is = process.getInputStream();
                 InputStreamReader isr = new InputStreamReader(is, "UTF-8");
                 BufferedReader br = new BufferedReader(isr);
@@ -51,7 +57,6 @@ class Scripter extends Thread {
             }catch(Exception e){
                 e.printStackTrace();
             }
-                        
         }
 }
 


### PR DESCRIPTION
This is a second attempt at https://github.com/RJ/irccat/pull/11

Added code to send "login" (the users ident) to the command handler. We needed this to be able to compare the user's ident on a private IRC server.

This can be enabled by including this in the config xml:

```
<fields>
    <includelogin>true</includelogin>
</fields>
```

Without this setting in the config, it should be backwards compatible.
