### PR TITLE
Support custom realname (version)

### DIFF
--- a/examples/irccat.xml
+++ b/examples/irccat.xml
@@ -14,6 +14,7 @@
 		<nick>irccat</nick>
 		<!-- The number of milliseconds between each outgoing message in the bot's queue -->
 		<messagedelay>250</messagedelay>
+		<version>irccat</version>
 	</bot>
 	
 	<!-- Address/port to listen on for data to cat to IRC -->

--- a/src/fm/last/irccat/IRCCat.java
+++ b/src/fm/last/irccat/IRCCat.java
@@ -100,6 +100,7 @@ public class IRCCat extends PircBot {
 		nick = config.getString("bot.nick");
 		setName(nick);
 		setLogin(nick);
+		setVersion(config.getString("bot.version", getVersion()));
 		setMessageDelay(config.getLong("bot.messagedelay", 1000));
 		setFinger(config.getString("bot.finger",
 				"IRCCat - a development support bot, used by Last.fm"));


### PR DESCRIPTION
This uses the PircBot 1.4.6 `setVersion` API. PircBot 1.5.0 has a setRealname which should be used instead if the dependency gets updated.

Can be set in the config xml, e.g.

```xml
<bot>
   <version>irccat real name</version>
</bot>
```